### PR TITLE
Tighten type definitions for useLocalStorage

### DIFF
--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-function useLocalStorage<T>(key: string, initialValue: T) {
+function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
   // Get from local storage then
   // parse stored json or return initialValue
   const readValue = () => {
@@ -20,7 +20,7 @@ function useLocalStorage<T>(key: string, initialValue: T) {
 
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = useState(readValue)
+  const [storedValue, setStoredValue] = useState<T>(readValue)
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.


### PR DESCRIPTION
- Specify the return type for the hook
- Pass type argument T to `useState()` so that we have typed values