### PR TITLE
Various improvements to useInterval hooks

### DIFF
--- a/src/hooks/useInterval/useInterval.ts
+++ b/src/hooks/useInterval/useInterval.ts
@@ -1,26 +1,25 @@
 import { useRef, useEffect } from 'react'
 
-function useInterval(callback: () => void, delay: number | null) {
-  const savedCallback = useRef<() => void | null>()
+export default function useInterval(
+  callback: () => void,
+  delay: number | null,
+) {
+  const savedCallback = useRef(callback)
 
-  // Remember the latest callback.
+  // Remember the latest callback if it changes.
   useEffect(() => {
     savedCallback.current = callback
-  })
+  }, [callback])
 
   // Set up the interval.
   useEffect(() => {
-    function tick() {
-      if (typeof savedCallback?.current !== 'undefined') {
-        savedCallback?.current()
-      }
+    // Don't schedule if no delay is specified.
+    if (delay === null) {
+      return
     }
 
-    if (delay !== null) {
-      const id = setInterval(tick, delay)
-      return () => clearInterval(id)
-    }
+    const id = setInterval(() => savedCallback.current(), delay)
+
+    return () => clearInterval(id)
   }, [delay])
 }
-
-export default useInterval


### PR DESCRIPTION
Includes the following changes
- `savedCallback` uses the callback as it's default value, removing the need to check for undefined values and allowing it's type to be inferred
- `savedCallback` will only have it's value updated if a new callback was specified (e.g. upstream memoized values will not be re-assigned)
- A delay with a null is handled in an early return, reducing nesting of code.