### PR TITLE
Even stronger type for eventName in useEventListener.ts

### DIFF
--- a/generated/hooks/useEventListener.hook.md
+++ b/generated/hooks/useEventListener.hook.md
@@ -1,7 +1,8 @@
-```tsimport { useRef, useEffect, RefObject } from 'react'
+```ts
+import { useRef, useEffect, RefObject } from 'react'
 
 function useEventListener<T extends HTMLElement = HTMLDivElement>(
-  eventName: string,
+  eventName: keyof WindowEventMap,
   handler: (event: Event) => void,
   element?: RefObject<T>,
 ) {
@@ -38,4 +39,4 @@ function useEventListener<T extends HTMLElement = HTMLDivElement>(
 }
 
 export default useEventListener
-```
+```

--- a/src/hooks/useEventListener/useEventListener.ts
+++ b/src/hooks/useEventListener/useEventListener.ts
@@ -1,7 +1,7 @@
 import { useRef, useEffect, RefObject } from 'react'
 
 function useEventListener<T extends HTMLElement = HTMLDivElement>(
-  eventName: string,
+  eventName: keyof WindowEventMap,
   handler: (event: Event) => void,
   element?: RefObject<T>,
 ) {


### PR DESCRIPTION
Hi, so string might be too lose of a type for this, since we could put some random string as an event.

`useEventListener("random", ()=>{})` didn't catch that "random" isn't an event listener type, so i updated it.